### PR TITLE
fix: push trailing cards to left

### DIFF
--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -94,6 +94,10 @@ const Section = styled.section`
 	justify-content: space-between;
 `;
 
+const TrailingPush = styled.div`
+	width: 30%
+`;
+
 class Card extends Component {
 	state = { categories: null };
 
@@ -123,7 +127,7 @@ class Card extends Component {
 								</CardWrapper>
 							</SlideInUp>
 						</Wrapper>)
-					)
+					).concat(Array(3).fill(<TrailingPush />))
 					: <Loading />}
 			</Section>
 		);


### PR DESCRIPTION
With this change the cards will get pushed to the left instead of leave an empty space in the middle.

![image](https://user-images.githubusercontent.com/5382443/36497235-04f25c3e-173b-11e8-90a4-35297c052d31.png)
